### PR TITLE
chore: Remove `?Send`

### DIFF
--- a/src/scanning/grpc/scanner.rs
+++ b/src/scanning/grpc/scanner.rs
@@ -374,7 +374,7 @@ where KM: TransactionKeyManagerInterface
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl<KM> BlockchainScanner for GrpcBlockchainScanner<KM>
 where KM: TransactionKeyManagerInterface
 {

--- a/src/scanning/http/scanner.rs
+++ b/src/scanning/http/scanner.rs
@@ -17,7 +17,7 @@ use tari_common_types::types::FixedHash;
 use tari_node_components::blocks::Block;
 use tari_transaction_components::{
     key_manager::TransactionKeyManagerInterface,
-    rpc::models::{BlockUtxoInfo, GetUtxosByBlockResponse, SyncUtxosByBlockResponseV0,SyncUtxosByBlockResponseV1},
+    rpc::models::{BlockUtxoInfo, GetUtxosByBlockResponse, SyncUtxosByBlockResponseV0, SyncUtxosByBlockResponseV1},
     transaction_components::TransactionOutput,
 };
 use tari_utilities::hex::Hex;
@@ -329,7 +329,7 @@ where KM: TransactionKeyManagerInterface
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl<KM> BlockchainScanner for HttpBlockchainScanner<KM>
 where KM: TransactionKeyManagerInterface
 {

--- a/src/scanning/interface.rs
+++ b/src/scanning/interface.rs
@@ -9,7 +9,7 @@ use crate::{BlockHeaderInfo, BlockScanResult, ScanConfig, TipInfo, WalletResult}
 /// This trait provides a lightweight interface that can be implemented by
 /// different backend providers (gRPC, HTTP, etc.) without requiring heavy
 /// dependencies in the core library.
-#[async_trait(?Send)]
+#[async_trait]
 pub trait BlockchainScanner: Send + Sync {
     /// Scan for wallet outputs in the specified block range
     async fn scan_blocks(&mut self, config: &ScanConfig) -> WalletResult<(Vec<BlockScanResult>, bool)>;


### PR DESCRIPTION
Removes `?Send` so scanner can be used in multi-threaded environments.